### PR TITLE
Fix: rebase script

### DIFF
--- a/src/scripts/decorators/verify-args.js
+++ b/src/scripts/decorators/verify-args.js
@@ -12,9 +12,7 @@ export function verifyArgs(fn) {
 
     const allValidCommands = Object.values(VALID_COMMANDS).flat();
 
-    const invalidParam = args.find(
-      (param) => param[0] === '-' && !allValidCommands.includes(param),
-    );
+    const invalidParam = args.find((param) => param[0] === '-' && !allValidCommands.includes(param));
 
     if (invalidParam) {
       log.error(`Param ${invalidParam} is not a valid command. Type \`gs --help\` to see list of commands.`);

--- a/src/scripts/extra-tasks/help.js
+++ b/src/scripts/extra-tasks/help.js
@@ -28,20 +28,35 @@ export function help() {
 
   printSection('General:');
   printLine(formatFlags(NON_GIT_COMMANDS[VALID_COMMAND_TYPES.HELP]), 'Show this help message');
-  printLine(formatFlags(NON_GIT_COMMANDS[VALID_COMMAND_TYPES.EDITOR_VSC]), 'Set VS Code as the default git conflict editor');
+  printLine(
+    formatFlags(NON_GIT_COMMANDS[VALID_COMMAND_TYPES.EDITOR_VSC]),
+    'Set VS Code as the default git conflict editor',
+  );
   console.info();
 
   printSection('Commands:');
   printLine(`${formatFlags(VALID_COMMANDS[VALID_COMMAND_TYPES.ADD])} [files]`, 'Stage files (default: git add .)');
   printLine(`${formatFlags(VALID_COMMANDS[VALID_COMMAND_TYPES.MESSAGE])} <message>`, 'Commit with a message');
   printLine(`${formatFlags(VALID_COMMANDS[VALID_COMMAND_TYPES.CHECKOUT])} <branch>`, 'Switch to a branch');
-  printLine(`${formatFlags(VALID_COMMANDS[VALID_COMMAND_TYPES.CREATE_BRANCH])} <branch>`, 'Create and switch to a branch');
+  printLine(
+    `${formatFlags(VALID_COMMANDS[VALID_COMMAND_TYPES.CREATE_BRANCH])} <branch>`,
+    'Create and switch to a branch',
+  );
   printLine(formatFlags(VALID_COMMANDS[VALID_COMMAND_TYPES.CHECKOUT_DEFAULT]), 'Checkout and pull the default branch');
-  printLine(`${formatFlags(VALID_COMMANDS[VALID_COMMAND_TYPES.PULL])} [branch]`, 'Pull from origin (default: current branch)');
-  printLine(`${formatFlags(VALID_COMMANDS[VALID_COMMAND_TYPES.PUSH])} [branch]`, 'Push to origin (default: current branch)');
+  printLine(
+    `${formatFlags(VALID_COMMANDS[VALID_COMMAND_TYPES.PULL])} [branch]`,
+    'Pull from origin (default: current branch)',
+  );
+  printLine(
+    `${formatFlags(VALID_COMMANDS[VALID_COMMAND_TYPES.PUSH])} [branch]`,
+    'Push to origin (default: current branch)',
+  );
   printLine(formatFlags(VALID_COMMANDS[VALID_COMMAND_TYPES.FORCE]), 'Force push (use with -p or --push)');
   printLine(`${formatFlags(VALID_COMMANDS[VALID_COMMAND_TYPES.RESET_HEAD])} [n]`, 'Reset HEAD~n (default: 1)');
-  printLine(`${formatFlags(VALID_REBASE_FLAGS.rebase)} [head] [target]`, 'Rebase target onto head (defaults: default branch, current branch)');
+  printLine(
+    `${formatFlags(VALID_REBASE_FLAGS.rebase)} [head] [target]`,
+    'Rebase target onto head (defaults: default branch, current branch)',
+  );
   console.info();
 
   printSection('Commit message prefixes (use with -m or --message):');

--- a/src/scripts/run-tasks.js
+++ b/src/scripts/run-tasks.js
@@ -6,7 +6,7 @@ import { exec } from '#tasks';
 export async function runGitTask(currentArg, allArgs) {
   const commandType = mapFlagToCommandType(currentArg);
   const gitTask = mapCommandTypeToTask[commandType];
-  
+
   if (gitTask == null) return;
 
   const tasks = await gitTask(allArgs, commandType);

--- a/src/scripts/runner.js
+++ b/src/scripts/runner.js
@@ -7,17 +7,17 @@ async function runner(args) {
   try {
     for (const arg of args) {
       const isFlag = arg.indexOf('-') === 0;
-  
+
       if (!isFlag) continue;
-  
+
       if (Object.values(NON_GIT_COMMANDS).flat().includes(arg)) {
         await runNonGitTask(arg, args);
         continue;
       }
-  
+
       await runGitTask(arg, args);
     }
-  
+
     log.success('Git flow finished successfully!');
   } catch (error) {
     log.error(error.message);

--- a/src/scripts/tasks/rebase.task.js
+++ b/src/scripts/tasks/rebase.task.js
@@ -17,12 +17,12 @@ export async function gitRebaseTask(args, rebaseFlag) {
 
     const isValidHeadBranch = !allValidCommands.includes(head); // next argument is not a git comment
     const validHeadBranch = head && isValidHeadBranch ? head : defaultBranch; // default to default branch (e.g. main or develop)
-
-    if (isValidHeadBranch && !origin) throw new Error('Origin is required when rebasing to a branch other than the default branch.');
+    const isValidOriginBranch = !allValidCommands.includes(origin);
+    const validOrigin = origin && isValidOriginBranch ? origin : currentBranch; // default to currnet branch
 
     const goToHeadBranch = addTask('git', ['checkout', validHeadBranch]);
     const gitPull = addTask('git', ['pull', 'origin', validHeadBranch]);
-    const goToCurrentBranch = addTask('git', ['checkout', origin ?? currentBranch]);
+    const goToCurrentBranch = addTask('git', ['checkout', validOrigin]);
     const makeRebase = addTask('git', ['rebase', validHeadBranch]);
 
     return [goToHeadBranch, gitPull, goToCurrentBranch, makeRebase];
@@ -30,16 +30,11 @@ export async function gitRebaseTask(args, rebaseFlag) {
 
   const hasAddFlag = args.some((arg) => VALID_COMMANDS[VALID_COMMAND_TYPES.ADD].includes(arg));
 
-  if (args.length > 1 && !hasAddFlag)
-    throw new Error(
-      `Invalid param ${args.slice(1).join(', ')}. Choose one flag to continue rebase \`-ra\`, \`-rs\` or \`-rc\` `,
-    );
-
   const flag = VALID_REBASE_FLAGS[rebaseFlag][1];
-  
+
   const gitRebase = addTask('git', ['rebase', flag]);
 
-  if (hasAddFlag) {
+  if (!hasAddFlag) {
     const gitAdd = addTask('git', ['add', '.']);
     return [gitAdd, gitRebase];
   }


### PR DESCRIPTION
- turn origin branch into an optional parameter
- fix `-a` flag on rebase continue script
- fix code format using prettier fix
- make it possible to use the rebase flags (`-ra`, `-rc`, and `-rs`) in chain